### PR TITLE
Refactor spdx parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,18 @@ Or install it yourself as:
 Spdx.valid_spdx?("(MIT OR AGPL-3.0+)")
 => true
 ```
+
 ```ruby
 Spdx.parse_spdx("MIT OR AGPL-3.0+")
- => LogicalOr+OrExpression4 offset=0, "MIT OR AGPL-3.0+":
+=> LogicalOr+OrExpression4 offset=0, "MIT OR AGPL-3.0+":
   License+LicenseId0 offset=0, "MIT" (idstring)
   LicensePlus+SimpleExpression0 offset=7, "AGPL-3.0+" (license_id):
     License+LicenseId0 offset=7, "AGPL-3.0" (idstring)
+```
+
+```ruby
+Spdx.normalize("Mit OR agpl-3.0+ AND APACHE-2.0")
+=> "(MIT OR (AGPL-3.0+ AND Apache-2.0))"
 ```
 
 ### Nodes

--- a/README.md
+++ b/README.md
@@ -25,12 +25,10 @@ Spdx.valid_spdx?("(MIT OR AGPL-3.0+)")
 ```
 ```ruby
 Spdx.parse_spdx("MIT OR AGPL-3.0+")
- => LogicalOr+CompoundExpression9 offset=0, "MIT OR AGPL-3.0+":
-  Operand+CompoundExpression5 offset=0, "MIT " (expression,space):
-    License+LicenseId0 offset=0, "MIT" (idstring)
-  Operand+CompoundExpression7 offset=6, " AGPL-3.0+" (space,compound_expression):
-    LicensePlus+SimpleExpression0 offset=7, "AGPL-3.0+" (license_id):
-      License+LicenseId0 offset=7, "AGPL-3.0" (idstring)
+ => LogicalOr+OrExpression4 offset=0, "MIT OR AGPL-3.0+":
+  License+LicenseId0 offset=0, "MIT" (idstring)
+  LicensePlus+SimpleExpression0 offset=7, "AGPL-3.0+" (license_id):
+    License+LicenseId0 offset=7, "AGPL-3.0" (idstring)
 ```
 
 ### Nodes
@@ -81,10 +79,6 @@ LogicalAnd
 #### `LogicalOr`
 
 The same as `LogicalAnd`, but for "OR" expressions.
-
-#### `GroupedExpression`
-
-This node represents expressions surrounded by parentheses, e.g. `Spdx.parse_spdx("(MIT OR LGPL-2.0)")` or `Spdx.parse_spdx("(MIT)")`. The child node can be found via the `child` method.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -69,17 +69,16 @@ This node represents a license with an SPDX-defined license exception, e.g. `Spd
 
 This node represents an "AND" expression, e.g. `Spdx.parse("LGPL-2.1-only AND MIT")`. This node has two extra methods, `left` and `right`, which return the node for the left side of the expression and the node for the right side of the expression, respectively. Any node can be the child of `LogicalAnd`, including `LogicalAnd`/`LogicalOr`.
 
-`Spdx.parse("(MIT AND GPL-1.0) AND MPL-2.0 AND Apache-2.0")` would result in the following tree:
+`Spdx.parse("(MIT AND GPL-1.0) OR MPL-2.0 AND Apache-2.0")` would result in the following tree:
 
 ```txt
-LogicalAnd
-├── GroupedExpression
-│   └── LogicalAnd
-│       ├── License (MIT)
-│       └── License (GPL-1.0)
+LogicalOr
+├── LogicalAnd
+│   ├── License (MIT)
+│   └── License (GPL-1.0)
 └── LogicalAnd
     ├── License (MPL-2.0)
-    └── License (Apache-2.0)
+    └── License Apache-2.0
 ```
 
 #### `LogicalOr`
@@ -90,7 +89,9 @@ The same as `LogicalAnd`, but for "OR" expressions.
 
 Run the tests with:
 
-    $ bundle exec rspec
+```sh
+bundle exec rspec
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
-Spdx.valid_spdx?("(MIT OR AGPL-3.0+)")
+Spdx.valid?("(MIT OR AGPL-3.0+)")
 => true
 ```
 
 ```ruby
-Spdx.parse_spdx("MIT OR AGPL-3.0+")
+Spdx.parse("MIT OR AGPL-3.0+")
 => LogicalOr+OrExpression4 offset=0, "MIT OR AGPL-3.0+":
   License+LicenseId0 offset=0, "MIT" (idstring)
   LicensePlus+SimpleExpression0 offset=7, "AGPL-3.0+" (license_id):
@@ -43,19 +43,19 @@ Parsed SPDX license expressions can be a number of various nodes. Each of these 
 
 #### `License`
 
-This node represents a single license, and is the result of the most simple form of expression, e.g. `Spdx.parse_spdx("MIT")`. It can also be found as a child node of other nodes.
+This node represents a single license, and is the result of the most simple form of expression, e.g. `Spdx.parse("MIT")`. It can also be found as a child node of other nodes.
 
 #### `LicensePlus`
 
-This node represents the current version of a license or any later version, e.g. `Spdx.parse_spdx("CDDL-1.0+")`. The inner license node can be found via the `child` method.
+This node represents the current version of a license or any later version, e.g. `Spdx.parse("CDDL-1.0+")`. The inner license node can be found via the `child` method.
 
 #### `LicenseRef`
 
-This node represents a reference to a license not defined in the SPDX license list, e.g. `Spdx.parse_spdx("LicenseRef-23")`.
+This node represents a reference to a license not defined in the SPDX license list, e.g. `Spdx.parse("LicenseRef-23")`.
 
 #### `DocumentRef`
 
-Similar to `LicenseRef`, this node also represents a reference to a license not defined in the SPDX license list, e.g. `Spdx.parse_spdx("DocumentRef-spdx-tool-1.2:LicenseRef-MIT-Style-2")`.
+Similar to `LicenseRef`, this node also represents a reference to a license not defined in the SPDX license list, e.g. `Spdx.parse("DocumentRef-spdx-tool-1.2:LicenseRef-MIT-Style-2")`.
 
 #### `LicenseException`
 
@@ -63,13 +63,13 @@ This node represents an exception to a license. See `With`.
 
 #### `With`
 
-This node represents a license with an SPDX-defined license exception, e.g. `Spdx.parse_spdx("GPL-2.0-or-later WITH Bison-exception-2.2")`. This node has two extra methods, `license` and `exception`, which return the nodes for the license portion of the expression and the exception portion of the expression, respectively.
+This node represents a license with an SPDX-defined license exception, e.g. `Spdx.parse("GPL-2.0-or-later WITH Bison-exception-2.2")`. This node has two extra methods, `license` and `exception`, which return the nodes for the license portion of the expression and the exception portion of the expression, respectively.
 
 #### `LogicalAnd`
 
-This node represents an "AND" expression, e.g. `Spdx.parse_spdx("LGPL-2.1-only AND MIT")`. This node has two extra methods, `left` and `right`, which return the node for the left side of the expression and the node for the right side of the expression, respectively. Any node can be the child of `LogicalAnd`, including `LogicalAnd`/`LogicalOr`.
+This node represents an "AND" expression, e.g. `Spdx.parse("LGPL-2.1-only AND MIT")`. This node has two extra methods, `left` and `right`, which return the node for the left side of the expression and the node for the right side of the expression, respectively. Any node can be the child of `LogicalAnd`, including `LogicalAnd`/`LogicalOr`.
 
-`Spdx.parse_spdx("(MIT AND GPL-1.0) AND MPL-2.0 AND Apache-2.0")` would result in the following tree:
+`Spdx.parse("(MIT AND GPL-1.0) AND MPL-2.0 AND Apache-2.0")` would result in the following tree:
 
 ```txt
 LogicalAnd

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Spdx.parse("MIT OR AGPL-3.0+")
 
 ```ruby
 Spdx.normalize("Mit OR agpl-3.0+ AND APACHE-2.0")
+=> "MIT OR (AGPL-3.0+ AND Apache-2.0)"
+
+Spdx.normalize("Mit OR agpl-3.0+ AND APACHE-2.0", top_level_parens: true)
 => "(MIT OR (AGPL-3.0+ AND Apache-2.0))"
 ```
 

--- a/lib/spdx.rb
+++ b/lib/spdx.rb
@@ -61,6 +61,35 @@ module Spdx
     @exceptions_downcase
   end
 
+  def self.normalize(spdx_string)
+    normalize_tree(SpdxParser.parse(spdx_string))
+  end
+
+  private_class_method def self.normalize_tree(node)
+    case node
+    when SpdxGrammar::LogicalAnd
+      "(#{normalize_tree(node.left)} AND #{normalize_tree(node.right)})"
+    when SpdxGrammar::LogicalOr
+      "(#{normalize_tree(node.left)} OR #{normalize_tree(node.right)})"
+    when SpdxGrammar::With
+      "(#{normalize_tree(node.license)} WITH #{normalize_tree(node.exception)})"
+    when SpdxGrammar::None
+      "NONE"
+    when SpdxGrammar::NoAssertion
+      "NOASSERTION"
+    when SpdxGrammar::License
+      licenses_downcase[node.text_value.downcase]
+    when SpdxGrammar::LicensePlus
+      "#{normalize_tree(node.child)}+"
+    when SpdxGrammar::LicenseRef
+      node.text_value
+    when SpdxGrammar::DocumentRef
+      node.text_value
+    when SpdxGrammar::LicenseException
+      exceptions_downcase[node.text_value.downcase]
+    end
+  end
+
   def self.valid_spdx?(spdx_string)
     return false unless spdx_string.is_a?(String)
 

--- a/lib/spdx.rb
+++ b/lib/spdx.rb
@@ -61,18 +61,36 @@ module Spdx
     @exceptions_downcase
   end
 
-  def self.normalize(spdx_string)
-    normalize_tree(SpdxParser.parse(spdx_string))
+  def self.normalize(spdx_string, top_level_parens: false)
+    normalize_tree(SpdxParser.parse(spdx_string), parens: top_level_parens)
   end
 
-  private_class_method def self.normalize_tree(node)
+  private_class_method def self.normalize_tree(node, parens: true)
     case node
     when SpdxGrammar::LogicalAnd
-      "(#{normalize_tree(node.left)} AND #{normalize_tree(node.right)})"
+      left = normalize_tree(node.left)
+      right = normalize_tree(node.right)
+      if parens
+        "(#{left} AND #{right})"
+      else
+        "#{left} AND #{right}"
+      end
     when SpdxGrammar::LogicalOr
-      "(#{normalize_tree(node.left)} OR #{normalize_tree(node.right)})"
+      left = normalize_tree(node.left)
+      right = normalize_tree(node.right)
+      if parens
+        "(#{left} OR #{right})"
+      else
+        "#{left} OR #{right}"
+      end
     when SpdxGrammar::With
-      "(#{normalize_tree(node.license)} WITH #{normalize_tree(node.exception)})"
+      license = normalize_tree(node.license)
+      exception = normalize_tree(node.exception)
+      if parens
+        "(#{license} WITH #{exception})"
+      else
+        "#{license} WITH #{exception}"
+      end
     when SpdxGrammar::None
       "NONE"
     when SpdxGrammar::NoAssertion

--- a/lib/spdx.rb
+++ b/lib/spdx.rb
@@ -90,7 +90,7 @@ module Spdx
     end
   end
 
-  def self.valid_spdx?(spdx_string)
+  def self.valid?(spdx_string)
     return false unless spdx_string.is_a?(String)
 
     SpdxParser.parse(spdx_string)
@@ -99,7 +99,7 @@ module Spdx
     false
   end
 
-  def self.parse_spdx(spdx_string)
+  def self.parse(spdx_string)
     SpdxParser.parse(spdx_string)
   end
 end

--- a/lib/spdx/version.rb
+++ b/lib/spdx/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spdx
-  VERSION = "3.1.0"
+  VERSION = "4.0.0"
 end

--- a/lib/spdx_grammar.rb
+++ b/lib/spdx_grammar.rb
@@ -1,19 +1,51 @@
 # frozen_string_literal: true
 
 module SpdxGrammar
-  class CompoundExpression < Treetop::Runtime::SyntaxNode
+  class GroupedExpression < Treetop::Runtime::SyntaxNode
     def licenses
-      elements[0].licenses
+      child.licenses
+    end
+
+    def child
+      elements[0]
     end
   end
 
-  class LogicalOr < Treetop::Runtime::SyntaxNode
+  class LogicalBinary < Treetop::Runtime::SyntaxNode
+    def licenses
+      (left.licenses + right.licenses).uniq
+    end
+
+    def left
+      elements[0].elements[0]
+    end
+
+    def right
+      elements[1].elements[0]
+    end
   end
 
-  class LogicalAnd < Treetop::Runtime::SyntaxNode
+  class LogicalAnd < LogicalBinary
+  end
+
+  class LogicalOr < LogicalBinary
+  end
+
+  class Operand < Treetop::Runtime::SyntaxNode
   end
 
   class With < Treetop::Runtime::SyntaxNode
+    def licenses
+      license.licenses
+    end
+
+    def license
+      elements[0]
+    end
+
+    def exception
+      elements[1]
+    end
   end
 
   class None < Treetop::Runtime::SyntaxNode
@@ -30,33 +62,34 @@ module SpdxGrammar
 
   class License < Treetop::Runtime::SyntaxNode
     def licenses
-      text_value
+      [text_value]
     end
   end
 
-  class UserDefinedLicense < Treetop::Runtime::SyntaxNode
+  class LicensePlus < Treetop::Runtime::SyntaxNode
+    def licenses
+      child.licenses
+    end
+
+    def child
+      elements[0]
+    end
   end
 
   class LicenseRef < Treetop::Runtime::SyntaxNode
     def licenses
-      text_value
+      [text_value]
     end
   end
 
   class DocumentRef < Treetop::Runtime::SyntaxNode
     def licenses
-      text_value
+      [text_value]
     end
   end
 
   class LicenseException < Treetop::Runtime::SyntaxNode
     # TODO: actually do license exceptions
-  end
-
-  class Body < Treetop::Runtime::SyntaxNode
-    def licenses
-      elements.map { |node| node.licenses if node.respond_to?(:licenses) }.flatten.uniq.compact
-    end
   end
 
   class SpdxParseError < StandardError

--- a/lib/spdx_grammar.rb
+++ b/lib/spdx_grammar.rb
@@ -1,27 +1,19 @@
 # frozen_string_literal: true
 
 module SpdxGrammar
-  class GroupedExpression < Treetop::Runtime::SyntaxNode
-    def licenses
-      child.licenses
-    end
-
-    def child
-      elements[0]
-    end
-  end
-
   class LogicalBinary < Treetop::Runtime::SyntaxNode
+    # Used internally
+
     def licenses
       (left.licenses + right.licenses).uniq
     end
 
     def left
-      elements[0].elements[0]
+      elements[0]
     end
 
     def right
-      elements[1].elements[0]
+      elements[1]
     end
   end
 
@@ -29,9 +21,6 @@ module SpdxGrammar
   end
 
   class LogicalOr < LogicalBinary
-  end
-
-  class Operand < Treetop::Runtime::SyntaxNode
   end
 
   class With < Treetop::Runtime::SyntaxNode
@@ -90,6 +79,14 @@ module SpdxGrammar
 
   class LicenseException < Treetop::Runtime::SyntaxNode
     # TODO: actually do license exceptions
+  end
+
+  class GroupedExpression < Treetop::Runtime::SyntaxNode
+    # Used internally
+  end
+
+  class Operand < Treetop::Runtime::SyntaxNode
+    # Used internally
   end
 
   class SpdxParseError < StandardError

--- a/lib/spdx_parser.rb
+++ b/lib/spdx_parser.rb
@@ -21,8 +21,6 @@ class SpdxParser
 
   private_class_method def self.parse_tree(data)
     parser = SpdxGrammarParser.new # The generated grammar parser is not thread safe
-    # Couldn't figure out treetop to make parens optional
-    data = "(#{data})" unless SKIP_PARENS.include?(data)
 
     tree = parser.parse(data)
     raise SpdxGrammar::SpdxParseError, "Unable to parse expression '#{data}'. Parse error at offset: #{parser.index}" if tree.nil?

--- a/lib/spdx_parser.rb
+++ b/lib/spdx_parser.rb
@@ -25,14 +25,44 @@ class SpdxParser
     tree = parser.parse(data)
     raise SpdxGrammar::SpdxParseError, "Unable to parse expression '#{data}'. Parse error at offset: #{parser.index}" if tree.nil?
 
-    clean_tree(tree)
-    tree
+    prune(tree)
   end
 
-  private_class_method def self.clean_tree(root_node)
-    return if root_node.elements.nil?
+  private_class_method def self.clean(root_node)
+    root_node.elements&.delete_if { |node| node.instance_of?(Treetop::Runtime::SyntaxNode) }
+  end
 
-    root_node.elements.delete_if { |node| node.class.name == "Treetop::Runtime::SyntaxNode" }
-    root_node.elements.each { |node| clean_tree(node) }
+  private_class_method def self.prune(root_node)
+    clean(root_node)
+
+    root_node.elements&.each_with_index do |node, i|
+      case node
+      when SpdxGrammar::GroupedExpression, SpdxGrammar::Operand
+        clean(node)
+        child = node.elements[0]
+        child.parent = root_node
+        root_node.elements[i] = child
+
+        case child
+        when SpdxGrammar::GroupedExpression, SpdxGrammar::Operand
+          # re-prune if child's child is a GroupedExpression or Operand
+          prune(root_node)
+        else
+          prune(child)
+        end
+      else
+        prune(node)
+      end
+    end
+
+    case root_node
+    when SpdxGrammar::GroupedExpression
+      child = root_node.elements[0]
+      child.parent = root_node.parent
+
+      return child
+    end
+
+    root_node
   end
 end

--- a/lib/spdx_parser.treetop
+++ b/lib/spdx_parser.treetop
@@ -5,10 +5,7 @@ grammar SpdxGrammar
   end
 
   rule compound_expression
-    or_expression /
-    and_expression /
-    expression /
-    grouped_expression
+    or_expression / and_expression / expression / grouped_expression
   end
 
   rule and_expression

--- a/lib/spdx_parser.treetop
+++ b/lib/spdx_parser.treetop
@@ -5,10 +5,18 @@ grammar SpdxGrammar
   end
 
   rule compound_expression
-    ( expression space <Operand> / grouped_expression space? <Operand> ) "AND" ( space compound_expression <Operand> / space? grouped_expression <Operand> ) <LogicalAnd> /
-    ( expression space <Operand> / grouped_expression space? <Operand> ) "OR"  ( space compound_expression <Operand> / space? grouped_expression <Operand> ) <LogicalOr> /
+    or_expression /
+    and_expression /
     expression /
     grouped_expression
+  end
+
+  rule and_expression
+    ( expression space <Operand> / grouped_expression space? <Operand> ) "AND" ( space ( and_expression / expression ) <Operand> / space? grouped_expression <Operand> ) <LogicalAnd>
+  end
+
+  rule or_expression
+    ( ( and_expression / expression ) space <Operand> / grouped_expression space? <Operand> ) "OR"  ( space compound_expression <Operand> / space? grouped_expression <Operand> ) <LogicalOr>
   end
 
   rule expression

--- a/lib/spdx_parser.treetop
+++ b/lib/spdx_parser.treetop
@@ -1,47 +1,51 @@
 grammar SpdxGrammar
 
-  rule spdx_expression
+  rule license_expression
     compound_expression / none / no_assertion
   end
 
   rule compound_expression
-    '(' body ')' <CompoundExpression>
+    ( expression space <Operand> / grouped_expression space? <Operand> ) "AND" ( space compound_expression <Operand> / space? grouped_expression <Operand> ) <LogicalAnd> /
+    ( expression space <Operand> / grouped_expression space? <Operand> ) "OR"  ( space compound_expression <Operand> / space? grouped_expression <Operand> ) <LogicalOr> /
+    expression /
+    grouped_expression
   end
 
-  rule body
-    ( compound_expression / and / or / with / license_ref / document_ref / license )* <Body>
+  rule expression
+    simple_expression space "WITH" space license_exception_id <With> /
+    simple_expression
   end
 
-  rule and
-    space "AND" space !reserve_words <LogicalAnd>
+  rule grouped_expression
+    '(' compound_expression ')' <GroupedExpression>
   end
 
-  rule or
-    space "OR" space !reserve_words <LogicalOr>
+  rule simple_expression
+    license_id '+' <LicensePlus> / license_id / ref
   end
 
-  rule with
-    space "WITH" space license_exception <With>
-  end
-
-  rule license
-    [a-zA-Z0-9\-\.\+]+ &{|seq| Spdx.license_exists?(seq.first.text_value) || Spdx.license_exists?(seq.first.text_value.delete_suffix('+')) }  <License>
+  rule ref
+    document_ref / license_ref
   end
 
   rule license_ref
-    "LicenseRef-" [a-zA-Z0-9\-\.]+ <LicenseRef>
+    "LicenseRef-" idstring <LicenseRef>
   end
 
   rule document_ref
-    "DocumentRef-" [a-zA-Z0-9\-\.]+ ":" license_ref <DocumentRef>
+    "DocumentRef-" idstring ':' license_ref <DocumentRef>
   end
 
-  rule license_exception
-    [a-zA-Z0-9\-\.]+ &{|seq| Spdx.exception_exists?(seq.first.text_value) } <LicenseException>
+  rule license_id
+    idstring &{|seq| Spdx.license_exists?(seq.first.text_value) } <License>
   end
 
-  rule reserve_words
-    "AND" / "OR" / "WITH"
+  rule license_exception_id
+    idstring &{|seq| Spdx.exception_exists?(seq.first.text_value) } <LicenseException>
+  end
+
+  rule idstring
+    [a-zA-Z0-9\-\.]+
   end
 
   rule none

--- a/spec/spdx_spec.rb
+++ b/spec/spdx_spec.rb
@@ -65,23 +65,33 @@ describe Spdx do
       expect(Spdx.normalize("NOASSERTION")).to eq "NOASSERTION"
     end
     it "normalizes boolean expressions" do
-      expect(Spdx.normalize("mit AND gPL-2.0")).to eq "(MIT AND GPL-2.0)"
-      expect(Spdx.normalize("mit OR gPL-2.0")).to eq "(MIT OR GPL-2.0)"
-      expect(Spdx.normalize("mit OR gPL-2.0")).to eq "(MIT OR GPL-2.0)"
+      expect(Spdx.normalize("mit AND gPL-2.0")).to eq "MIT AND GPL-2.0"
+      expect(Spdx.normalize("mit OR gPL-2.0")).to eq "MIT OR GPL-2.0"
+      expect(Spdx.normalize("mit OR gPL-2.0")).to eq "MIT OR GPL-2.0"
+
+      # With top level parens
+      expect(Spdx.normalize("mit AND gPL-2.0", top_level_parens: true)).to eq "(MIT AND GPL-2.0)"
+      expect(Spdx.normalize("mit OR gPL-2.0", top_level_parens: true)).to eq "(MIT OR GPL-2.0)"
+      expect(Spdx.normalize("mit OR gPL-2.0", top_level_parens: true)).to eq "(MIT OR GPL-2.0)"
 
       # Does semantic grouping
-      expect(Spdx.normalize("mit OR gPL-2.0 AND apAcHe-2.0+")).to eq "(MIT OR (GPL-2.0 AND Apache-2.0+))"
+      expect(Spdx.normalize("mit OR gPL-2.0 AND apAcHe-2.0+")).to eq "MIT OR (GPL-2.0 AND Apache-2.0+)"
 
       # But also preserves original groups
-      expect(Spdx.normalize("(mit OR gPL-2.0) AND apAcHe-2.0+")).to eq "((MIT OR GPL-2.0) AND Apache-2.0+)"
+      expect(Spdx.normalize("(mit OR gPL-2.0) AND apAcHe-2.0+")).to eq "(MIT OR GPL-2.0) AND Apache-2.0+"
     end
     it "normalizes WITH expressions" do
-      expect(Spdx.normalize("GPL-2.0-only WITH Classpath-exception-2.0")).to eq "(GPL-2.0-only WITH Classpath-exception-2.0)"
-      expect(Spdx.normalize("Gpl-2.0-ONLY WITH ClassPath-exception-2.0")).to eq "(GPL-2.0-only WITH Classpath-exception-2.0)"
-      expect(Spdx.normalize("EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0)")).to eq "(EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0))"
-      expect(Spdx.normalize("epl-2.0 OR (gpl-2.0-only WITH classpath-exception-2.0)")).to eq "(EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0))"
-      expect(Spdx.normalize("epl-2.0 OR gpl-2.0-only WITH classpath-exception-2.0")).to eq "(EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0))"
-      expect(Spdx.normalize("epl-2.0 OR gpl-2.0-only WITH classpath-exception-2.0 AND mpl-2.0+")).to eq "(EPL-2.0 OR ((GPL-2.0-only WITH Classpath-exception-2.0) AND MPL-2.0+))"
+      expect(Spdx.normalize("GPL-2.0-only WITH Classpath-exception-2.0")).to eq "GPL-2.0-only WITH Classpath-exception-2.0"
+      expect(Spdx.normalize("Gpl-2.0-ONLY WITH ClassPath-exception-2.0")).to eq "GPL-2.0-only WITH Classpath-exception-2.0"
+
+      # With top level parens
+      expect(Spdx.normalize("GPL-2.0-only WITH Classpath-exception-2.0", top_level_parens: true)).to eq "(GPL-2.0-only WITH Classpath-exception-2.0)"
+      expect(Spdx.normalize("Gpl-2.0-ONLY WITH ClassPath-exception-2.0", top_level_parens: true)).to eq "(GPL-2.0-only WITH Classpath-exception-2.0)"
+
+      expect(Spdx.normalize("EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0)")).to eq "EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0)"
+      expect(Spdx.normalize("epl-2.0 OR (gpl-2.0-only WITH classpath-exception-2.0)")).to eq "EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0)"
+      expect(Spdx.normalize("epl-2.0 OR gpl-2.0-only WITH classpath-exception-2.0")).to eq "EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0)"
+      expect(Spdx.normalize("epl-2.0 OR gpl-2.0-only WITH classpath-exception-2.0 AND mpl-2.0+")).to eq "EPL-2.0 OR ((GPL-2.0-only WITH Classpath-exception-2.0) AND MPL-2.0+)"
     end
   end
   context "licenses" do

--- a/spec/spdx_spec.rb
+++ b/spec/spdx_spec.rb
@@ -21,6 +21,8 @@ describe Spdx do
         expect(Spdx.valid_spdx?("MIT")).to be true
         expect(Spdx.valid_spdx?("MIT OR MPL-2.0 AND AGPL-1.0")).to be true
         expect(Spdx.valid_spdx?("MIT OR (GPL-1.0 OR MPL-2.0) AND AGPL-1.0")).to be true
+        expect(Spdx.valid_spdx?("MIT AND MPL-2.0 OR AGPL-1.0")).to be true
+        expect(Spdx.valid_spdx?("MIT AND (GPL-1.0 OR MPL-2.0) OR AGPL-1.0")).to be true
         expect(Spdx.valid_spdx?("MIT OR (DocumentRef-something-1:LicenseRef-MIT-style-1 OR MPL-2.0) AND AGPL-1.0")).to be true
         expect(Spdx.valid_spdx?("((MIT OR AGPL-1.0) AND (MIT OR MPL-2.0))")).to be true
         expect(Spdx.valid_spdx?("MIT OR (MIT)")).to be true

--- a/spec/spdx_spec.rb
+++ b/spec/spdx_spec.rb
@@ -4,47 +4,47 @@ require "spec_helper"
 
 describe Spdx do
   context "spdx parsing" do
-    context "valid_spdx?" do
+    context "valid?" do
       it "returns false for invalid spdx" do
-        expect(Spdx.valid_spdx?("AND AND")).to be false
-        expect(Spdx.valid_spdx?(" AND ")).to be false
-        expect(Spdx.valid_spdx?(" WITH ")).to be false
-        expect(Spdx.valid_spdx?("MIT AND ")).to be false
-        expect(Spdx.valid_spdx?("MIT OR MIT AND OR")).to be false
-        expect(Spdx.valid_spdx?("MIT OR FAKEYLICENSE")).to be false
-        expect(Spdx.valid_spdx?(nil)).to be false
-        expect(Spdx.valid_spdx?("")).to be false
-        expect(Spdx.valid_spdx?("MIT (MIT)")).to be false
+        expect(Spdx.valid?("AND AND")).to be false
+        expect(Spdx.valid?(" AND ")).to be false
+        expect(Spdx.valid?(" WITH ")).to be false
+        expect(Spdx.valid?("MIT AND ")).to be false
+        expect(Spdx.valid?("MIT OR MIT AND OR")).to be false
+        expect(Spdx.valid?("MIT OR FAKEYLICENSE")).to be false
+        expect(Spdx.valid?(nil)).to be false
+        expect(Spdx.valid?("")).to be false
+        expect(Spdx.valid?("MIT (MIT)")).to be false
       end
       it "returns true for valid spdx" do
-        expect(Spdx.valid_spdx?("(MIT OR MPL-2.0)")).to be true
-        expect(Spdx.valid_spdx?("MIT")).to be true
-        expect(Spdx.valid_spdx?("MIT OR MPL-2.0 AND AGPL-1.0")).to be true
-        expect(Spdx.valid_spdx?("MIT OR (GPL-1.0 OR MPL-2.0) AND AGPL-1.0")).to be true
-        expect(Spdx.valid_spdx?("MIT AND MPL-2.0 OR AGPL-1.0")).to be true
-        expect(Spdx.valid_spdx?("MIT AND (GPL-1.0 OR MPL-2.0) OR AGPL-1.0")).to be true
-        expect(Spdx.valid_spdx?("MIT OR (DocumentRef-something-1:LicenseRef-MIT-style-1 OR MPL-2.0) AND AGPL-1.0")).to be true
-        expect(Spdx.valid_spdx?("((MIT OR AGPL-1.0) AND (MIT OR MPL-2.0))")).to be true
-        expect(Spdx.valid_spdx?("MIT OR (MIT)")).to be true
+        expect(Spdx.valid?("(MIT OR MPL-2.0)")).to be true
+        expect(Spdx.valid?("MIT")).to be true
+        expect(Spdx.valid?("MIT OR MPL-2.0 AND AGPL-1.0")).to be true
+        expect(Spdx.valid?("MIT OR (GPL-1.0 OR MPL-2.0) AND AGPL-1.0")).to be true
+        expect(Spdx.valid?("MIT AND MPL-2.0 OR AGPL-1.0")).to be true
+        expect(Spdx.valid?("MIT AND (GPL-1.0 OR MPL-2.0) OR AGPL-1.0")).to be true
+        expect(Spdx.valid?("MIT OR (DocumentRef-something-1:LicenseRef-MIT-style-1 OR MPL-2.0) AND AGPL-1.0")).to be true
+        expect(Spdx.valid?("((MIT OR AGPL-1.0) AND (MIT OR MPL-2.0))")).to be true
+        expect(Spdx.valid?("MIT OR (MIT)")).to be true
       end
       it "returns true for NONE and NOASSERTION" do
-        expect(Spdx.valid_spdx?("NONE")).to be true
-        expect(Spdx.valid_spdx?("(NONE)")).to be false
-        expect(Spdx.valid_spdx?("NOASSERTION")).to be true
-        expect(Spdx.valid_spdx?("MIT OR NONE")).to be false
+        expect(Spdx.valid?("NONE")).to be true
+        expect(Spdx.valid?("(NONE)")).to be false
+        expect(Spdx.valid?("NOASSERTION")).to be true
+        expect(Spdx.valid?("MIT OR NONE")).to be false
       end
       it "returns true for + expression" do
-        expect(Spdx.valid_spdx?("AGPL-3.0+")).to be true
+        expect(Spdx.valid?("AGPL-3.0+")).to be true
       end
       it "is case insentive for license ids" do
-        expect(Spdx.valid_spdx?("mit OR agpl-3.0+")).to be true
+        expect(Spdx.valid?("mit OR agpl-3.0+")).to be true
       end
       it "handles LicenseRef" do
-        expect(Spdx.valid_spdx?("MIT OR LicenseRef-MIT-style-1")).to be true
+        expect(Spdx.valid?("MIT OR LicenseRef-MIT-style-1")).to be true
       end
       it "handles DocumentRef" do
-        expect(Spdx.valid_spdx?("MIT OR DocumentRef-something-1:LicenseRef-MIT-style-1")).to be true
-        expect(Spdx.valid_spdx?("MIT OR DocumentRef-something-1")).to be false
+        expect(Spdx.valid?("MIT OR DocumentRef-something-1:LicenseRef-MIT-style-1")).to be true
+        expect(Spdx.valid?("MIT OR DocumentRef-something-1")).to be false
       end
     end
   end
@@ -86,29 +86,29 @@ describe Spdx do
   end
   context "licenses" do
     it "returns a list of possible licenses" do
-      expect(Spdx.parse_spdx("MIT OR MPL-2.0").licenses).to eq ["MIT", "MPL-2.0"]
+      expect(Spdx.parse("MIT OR MPL-2.0").licenses).to eq ["MIT", "MPL-2.0"]
     end
     it "returns empty array for NONE or NOASSERTION" do
-      expect(Spdx.parse_spdx("NONE").licenses).to eq []
-      expect(Spdx.parse_spdx("NOASSERTION").licenses).to eq []
+      expect(Spdx.parse("NONE").licenses).to eq []
+      expect(Spdx.parse("NOASSERTION").licenses).to eq []
     end
     it "returns LicenseRefs" do
-      expect(Spdx.parse_spdx("MIT OR LicenseRef-MIT-style-1").licenses).to eq %w[MIT LicenseRef-MIT-style-1]
+      expect(Spdx.parse("MIT OR LicenseRef-MIT-style-1").licenses).to eq %w[MIT LicenseRef-MIT-style-1]
     end
     it "returns DocumentRefs" do
-      expect(Spdx.parse_spdx("MIT OR DocumentRef-something-1:LicenseRef-MIT-style-1").licenses).to eq %w[MIT DocumentRef-something-1:LicenseRef-MIT-style-1]
+      expect(Spdx.parse("MIT OR DocumentRef-something-1:LicenseRef-MIT-style-1").licenses).to eq %w[MIT DocumentRef-something-1:LicenseRef-MIT-style-1]
     end
   end
 
   context "exceptions" do
     it "parses a valid spdx WITH expression" do
-      expect(Spdx.valid_spdx?("EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0)")).to be true
+      expect(Spdx.valid?("EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0)")).to be true
     end
     it "returns false for a license in the exception spot" do
-      expect(Spdx.valid_spdx?("EPL-2.0 OR (GPL-2.0-only WITH AGPL-3.0)")).to be false
+      expect(Spdx.valid?("EPL-2.0 OR (GPL-2.0-only WITH AGPL-3.0)")).to be false
     end
     it "provides full details for a parse error" do
-      expect { Spdx.parse_spdx("MIT OR ((WHAT)") }.to raise_error(SpdxGrammar::SpdxParseError, "Unable to parse expression 'MIT OR ((WHAT)'. Parse error at offset: 3")
+      expect { Spdx.parse("MIT OR ((WHAT)") }.to raise_error(SpdxGrammar::SpdxParseError, "Unable to parse expression 'MIT OR ((WHAT)'. Parse error at offset: 3")
     end
   end
 end

--- a/spec/spdx_spec.rb
+++ b/spec/spdx_spec.rb
@@ -7,6 +7,9 @@ describe Spdx do
     context "valid_spdx?" do
       it "returns false for invalid spdx" do
         expect(Spdx.valid_spdx?("AND AND")).to be false
+        expect(Spdx.valid_spdx?(" AND ")).to be false
+        expect(Spdx.valid_spdx?(" WITH ")).to be false
+        expect(Spdx.valid_spdx?("MIT AND ")).to be false
         expect(Spdx.valid_spdx?("MIT OR MIT AND OR")).to be false
         expect(Spdx.valid_spdx?("MIT OR FAKEYLICENSE")).to be false
         expect(Spdx.valid_spdx?(nil)).to be false
@@ -16,6 +19,9 @@ describe Spdx do
       it "returns true for valid spdx" do
         expect(Spdx.valid_spdx?("(MIT OR MPL-2.0)")).to be true
         expect(Spdx.valid_spdx?("MIT")).to be true
+        expect(Spdx.valid_spdx?("MIT OR MPL-2.0 AND AGPL-1.0")).to be true
+        expect(Spdx.valid_spdx?("MIT OR (GPL-1.0 OR MPL-2.0) AND AGPL-1.0")).to be true
+        expect(Spdx.valid_spdx?("MIT OR (DocumentRef-something-1:LicenseRef-MIT-style-1 OR MPL-2.0) AND AGPL-1.0")).to be true
         expect(Spdx.valid_spdx?("((MIT OR AGPL-1.0) AND (MIT OR MPL-2.0))")).to be true
         expect(Spdx.valid_spdx?("MIT OR (MIT)")).to be true
       end
@@ -57,14 +63,14 @@ describe Spdx do
   end
 
   context "exceptions" do
-    it "parses a valid spdx with expression" do
+    it "parses a valid spdx WITH expression" do
       expect(Spdx.valid_spdx?("EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0)")).to be true
     end
     it "returns false for a license in the exception spot" do
       expect(Spdx.valid_spdx?("EPL-2.0 OR (GPL-2.0-only WITH AGPL-3.0)")).to be false
     end
     it "provides full details for a parse error" do
-      expect { Spdx.parse_spdx("MIT OR ((WHAT)") }.to raise_error(SpdxGrammar::SpdxParseError, "Unable to parse expression '(MIT OR ((WHAT))'. Parse error at offset: 0")
+      expect { Spdx.parse_spdx("MIT OR ((WHAT)") }.to raise_error(SpdxGrammar::SpdxParseError, "Unable to parse expression 'MIT OR ((WHAT)'. Parse error at offset: 3")
     end
   end
 end


### PR DESCRIPTION
This PR refactors how SPDX expressions are parsed, so expressions now take the shape of trees. Here's an example that I added to the README:

`Spdx.parse("(MIT AND GPL-1.0) OR MPL-2.0 AND Apache-2.0")` results in the following tree:

```txt
LogicalOr
├── LogicalAnd
│   ├── License (MIT)
│   └── License (GPL-1.0)
└── LogicalAnd
    ├── License (MPL-2.0)
    └── License Apache-2.0
```

The purpose of this change is to make the resulting AST easier to understand and navigate, as well as more closely follow the [official SPDX parsing rules](https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/#overview). 

The main deviations that you'll find from the official grammar are the parsing of `AND`/`OR` expressions. The official ABNF grammar doesn't convey evaluation semantics (and shouldn't), but an AST _should_ convey the meaning of the input. For that reason, limitations of PEG grammars (which are what Treetop uses), and spacing (which I'll get into in a second), are why the grammar in the `.treetop` file and the official ABNF are somewhat different. 

There's some funkiness around spacing. This is because the spacing is not defined in the grammar, but rather as separate instructions, which only _imply_ where spaces are allowed. I took the instructions to mean that spaces are only allowed in `AND`/`OR`/`WITH` expressions (and required if the adjacent operands are not surrounded by parens). An argument can be made that spaces are allowed around parens as well, but I did not implement that. From the ABNF specification that they link to:
> NOTE:
>
>      This specification for ABNF does not provide for implicit
>      specification of linear white space.
>
>   Any grammar that wishes to permit linear white space around delimiters or string segments must specify it explicitly.

¯\_(ツ)_/¯

For this reason, we probably should raise an issue over at https://github.com/spdx/spdx-spec for clarification and to potentially contribute the response to the spec.

If you care about what changes I did exactly to parse the grammar, it's at the bottom.

I also implemented `Spdx.normalize`, which takes a valid SPDX string and does case correction and puts parentheses in the right places, since I've seen this library used this way.

```ruby
Spdx.normalize("Mit OR agpl-3.0+ AND APACHE-2.0")
=> "(MIT OR (AGPL-3.0+ AND Apache-2.0))"
```

Since this was already a breaking change due to the resulting ASTs changing, I also took the liberty for @jsonperl to rename `Spdx.parse_spdx` -> `Spdx.parse` and `Spdx.valid_spdx?` -> `Spdx.valid?`.

That's about it. Let me know if there are any additional tests that should be written.

---

### Grammar changes to make parsing work

There are three key things that contribute to the divergence of this PEG from the ABNF grammar provided.
1. No left recursion
2. Operator precedence
3. Spacing

#### No left recursion

The ABNF describes `compound-expression` as containing `compound-expression "AND" compound-expression`. Makes sense, but PEGs can't support it. It'll try to find a `compound-expression` which in turn will look for `compound-expression "AND" compound-expression`, which, you guessed it, starts by looking for a `compound-expression` again, winding up in an infinite loop. It's actually really easy to solve in this case. You can just decide that `AND`/`OR` expressions can never have an `AND`/`OR` expression (that's not surrounded by parens) on the left-hand side of an `AND` or an `OR`. This means that `A AND B AND C` will always parse as `and(A, and(B, C))` and never as `and(and(A, B), C)`, but that's fine since it still satisfies the ABNF grammar. 

Essentially, the `compound-expression "AND" compound-expression` rule changes to:
 ```
( simple-expression / '(' compound-expression ')' ) "AND" compound-expression
```

It's the same for `OR` expressions.

#### Operator precedence

You might have just said to yourself: "Well, hold on, what about `A AND B OR C`? Wouldn't you get `and(A, or(B, C))`?" and you'd be absolutely correct. PEGs really suck at operator precedence, since you more or less have to write the precedence into your rules instead of defining relations. Thankfully, we've only got two operators. An ungrouped `OR` expression should never appear on either side of an `AND` expression, i.e. `MIT AND GPL OR Apache` should never be `and(MIT, or(GPL, Apache))`. We already banned boolean operators from the left side of `AND`, so we just need to ban `OR`s from the right side. Our rule becomes:

 ```
( simple-expression / '(' compound-expression ')' ) "AND" ( and-expression / simple-expression / '(' compound-expression ')' )
```

For `OR` expressions, we're pretty much okay, but we _do_ want to allow `AND` expressions on the left side, so that needs to be added back in.

#### Spacing

The extra bit about spacing in the spec says that you MUST always have spaces and/or parens around `AND` and `OR`. I took that to mean `MIT AND GPL-2.0` or `(MIT)AND(GPL-2.0)`, and I really hope that did not mean `MIT(AND)GPL-2.0`, but the spec text is unclear. As much as we'd like to just slap `space? "AND" space?` in the middle of our rule, that would only work because license names are parsed greedily. I felt it would be better to explicitly state the intention in the rules. Adding the spacing to the rule is an exercise left to the reader (or just look at how it's done in the `.treetop` file).