### PR TITLE
Handle attempts to parse nil

### DIFF
--- a/lib/spdx/version.rb
+++ b/lib/spdx/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spdx
-  VERSION = "4.0.0"
+  VERSION = "4.0.1"
 end

--- a/lib/spdx_parser.rb
+++ b/lib/spdx_parser.rb
@@ -11,6 +11,7 @@ class SpdxParser
   SKIP_PARENS = ["NONE", "NOASSERTION", ""].freeze
 
   def self.parse(data)
+    data ||= ""
     parse_tree(data)
   end
 

--- a/spec/spdx_spec.rb
+++ b/spec/spdx_spec.rb
@@ -4,6 +4,28 @@ require "spec_helper"
 
 describe Spdx do
   context "spdx parsing" do
+    context "parse" do
+      it "handles bad input" do
+        expect { Spdx.parse(nil) }.to raise_error(SpdxGrammar::SpdxParseError)
+        expect { Spdx.parse("") }.to raise_error(SpdxGrammar::SpdxParseError)
+      end
+      it "parses into respective classes" do
+        expect(Spdx.parse("MIT")).to be_an_instance_of(SpdxGrammar::License)
+        expect(Spdx.parse("MIT AND Apache-2.0")).to be_an_instance_of(SpdxGrammar::LogicalAnd)
+        expect(Spdx.parse("(MIT AND Apache-2.0)")).to be_an_instance_of(SpdxGrammar::LogicalAnd)
+        expect(Spdx.parse("MIT OR Apache-2.0")).to be_an_instance_of(SpdxGrammar::LogicalOr)
+        expect(Spdx.parse("MIT AND Apache-2.0").left).to be_an_instance_of(SpdxGrammar::License)
+        expect(Spdx.parse("MIT AND Apache-2.0").right).to be_an_instance_of(SpdxGrammar::License)
+        expect(Spdx.parse("MIT+")).to be_an_instance_of(SpdxGrammar::LicensePlus)
+        expect(Spdx.parse("LicenseRef-MIT-style-1")).to be_an_instance_of(SpdxGrammar::LicenseRef)
+        expect(Spdx.parse("DocumentRef-something-1:LicenseRef-MIT-style-1")).to be_an_instance_of(SpdxGrammar::DocumentRef)
+        expect(Spdx.parse("GPL-2.0-only WITH Classpath-exception-2.0")).to be_an_instance_of(SpdxGrammar::With)
+        expect(Spdx.parse("GPL-2.0-only WITH Classpath-exception-2.0").license).to be_an_instance_of(SpdxGrammar::License)
+        expect(Spdx.parse("GPL-2.0-only WITH Classpath-exception-2.0").exception).to be_an_instance_of(SpdxGrammar::LicenseException)
+        expect(Spdx.parse("NONE")).to be_an_instance_of(SpdxGrammar::None)
+        expect(Spdx.parse("NOASSERTION")).to be_an_instance_of(SpdxGrammar::NoAssertion)
+      end
+    end
     context "valid?" do
       it "returns false for invalid spdx" do
         expect(Spdx.valid?("AND AND")).to be false


### PR DESCRIPTION
In the old version, it always wrapped the toplevel statement with parens, which forced the input to be a string. It doesn't do that anymore, which means that the parser would fail with a cryptic error rather than `SpdxParser::ParseError` if given `nil`. I fixed this, and added some more tests.