### PR TITLE
Report 'license plus' licenses with the plus sign

### DIFF
--- a/lib/spdx/version.rb
+++ b/lib/spdx/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spdx
-  VERSION = "4.0.1"
+  VERSION = "4.0.2"
 end

--- a/lib/spdx_grammar.rb
+++ b/lib/spdx_grammar.rb
@@ -57,7 +57,7 @@ module SpdxGrammar
 
   class LicensePlus < Treetop::Runtime::SyntaxNode
     def licenses
-      child.licenses
+      child.licenses.map { |license| "#{license}+" }
     end
 
     def child

--- a/spec/spdx_spec.rb
+++ b/spec/spdx_spec.rb
@@ -118,7 +118,10 @@ describe Spdx do
   end
   context "licenses" do
     it "returns a list of possible licenses" do
+      expect(Spdx.parse("MIT").licenses).to eq ["MIT"]
       expect(Spdx.parse("MIT OR MPL-2.0").licenses).to eq ["MIT", "MPL-2.0"]
+      expect(Spdx.parse("MIT OR MPL-2.0+").licenses).to eq ["MIT", "MPL-2.0+"]
+      expect(Spdx.parse("GPL-2.0-only WITH Classpath-exception-2.0").licenses).to eq ["GPL-2.0-only"]
     end
     it "returns empty array for NONE or NOASSERTION" do
       expect(Spdx.parse("NONE").licenses).to eq []


### PR DESCRIPTION
This PR fixes an issue where "LicensePlus" nodes would incorrectly report the license identifier.